### PR TITLE
chore: approve pnpm builds and bump node to 26

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Node.js environment
         uses: actions/setup-node@v6.4.0
         with:
-          node-version: 22
+          node-version: 26
       - name: Setup pnpm
         run: |
           npm install --global pnpm

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+allowBuilds:
+  '@parcel/watcher': true
+  esbuild: true


### PR DESCRIPTION
- Approve build scripts for `@parcel/watcher` and `esbuild` (via `pnpm-workspace.yaml` written by `pnpm approve-builds --all`) — fixes the `ERR_PNPM_IGNORED_BUILDS` CI failure
- Bump CI Node.js from 22 to 26